### PR TITLE
fix: improve package.json resolution & fix license plist generation

### DIFF
--- a/packages/with-react-native-oss-notice/plugin-utils/src/common.ts
+++ b/packages/with-react-native-oss-notice/plugin-utils/src/common.ts
@@ -134,7 +134,7 @@ export function generateLicensePlistNPMOutput(licenses: Record<string, LicenseOb
     .reduce((acc, yamlPayload) => {
       return (
         acc +
-        `  - name: "${yamlPayload.name}"
+        `  - name: "${yamlPayload.name.replace(/\//g, '／')}"
     version: ${yamlPayload.version}
 ${yamlPayload.source ? `    source: ${yamlPayload.source}\n` : ''}    body: |-\n      ${yamlPayload.body
           .split('\n')

--- a/packages/with-react-native-oss-notice/plugin-utils/src/common.ts
+++ b/packages/with-react-native-oss-notice/plugin-utils/src/common.ts
@@ -79,24 +79,28 @@ export function scanDependencies(appPackageJsonPath: string) {
 
   return Object.keys(dependencies).reduce(
     (acc, dependency) => {
-      const localPackageJsonPath = require.resolve(`${dependency}/package.json`);
-      const localPackageJson = require(path.resolve(localPackageJsonPath));
-      const licenseFiles = glob.sync('LICEN{S,C}E{.md,}', {
-        cwd: path.dirname(localPackageJsonPath),
-        absolute: true,
-        nocase: true,
-        nodir: true,
-        ignore: '**/{__tests__,__fixtures__,__mocks__}/**',
-      });
+      try {
+        const localPackageJsonPath = require.resolve(`${dependency}/package.json`);
+        const localPackageJson = require(path.resolve(localPackageJsonPath));
+        const licenseFiles = glob.sync('LICEN{S,C}E{.md,}', {
+          cwd: path.dirname(localPackageJsonPath),
+          absolute: true,
+          nocase: true,
+          nodir: true,
+          ignore: '**/{__tests__,__fixtures__,__mocks__}/**',
+        });
 
-      acc[dependency] = {
-        author: parseAuthorField(localPackageJson),
-        content: licenseFiles?.[0] ? fs.readFileSync(licenseFiles[0], { encoding: 'utf-8' }) : undefined,
-        description: localPackageJson.description,
-        type: parseLicenseField(localPackageJson),
-        url: parseRepositoryFieldToUrl(localPackageJson),
-        version: localPackageJson.version,
-      };
+        acc[dependency] = {
+          author: parseAuthorField(localPackageJson),
+          content: licenseFiles?.[0] ? fs.readFileSync(licenseFiles[0], { encoding: 'utf-8' }) : undefined,
+          description: localPackageJson.description,
+          type: parseLicenseField(localPackageJson),
+          url: parseRepositoryFieldToUrl(localPackageJson),
+          version: localPackageJson.version,
+        };
+      } catch (error) {
+        console.warn(`package.json is not exported for ${dependency}`);
+      }
 
       return acc;
     },

--- a/packages/with-react-native-oss-notice/plugin-utils/src/common.ts
+++ b/packages/with-react-native-oss-notice/plugin-utils/src/common.ts
@@ -134,7 +134,7 @@ export function generateLicensePlistNPMOutput(licenses: Record<string, LicenseOb
     .reduce((acc, yamlPayload) => {
       return (
         acc +
-        `  - name: ${yamlPayload.name}
+        `  - name: "${yamlPayload.name}"
     version: ${yamlPayload.version}
 ${yamlPayload.source ? `    source: ${yamlPayload.source}\n` : ''}    body: |-\n      ${yamlPayload.body
           .split('\n')

--- a/packages/with-react-native-oss-notice/plugin-utils/src/common.ts
+++ b/packages/with-react-native-oss-notice/plugin-utils/src/common.ts
@@ -140,7 +140,7 @@ export function generateLicensePlistNPMOutput(licenses: Record<string, LicenseOb
     .reduce((acc, yamlPayload) => {
       return (
         acc +
-        `  - name: "${yamlPayload.name.replace(/\//g, '／')}"
+        `  - name: "${normalizePackageName(yamlPayload.name)}"
     version: ${yamlPayload.version}
 ${yamlPayload.source ? `    source: ${yamlPayload.source}\n` : ''}    body: |-\n      ${yamlPayload.body
           .split('\n')
@@ -193,7 +193,7 @@ export function generateAboutLibrariesNPMOutput(licenses: Record<string, License
         name: dependency,
         tag: '',
         type: licenseObj.type,
-        uniqueId: dependency.replace('/', '_'),
+        uniqueId: normalizePackageName(dependency),
       };
     })
     .map((jsonPayload) => {
@@ -212,7 +212,10 @@ export function generateAboutLibrariesNPMOutput(licenses: Record<string, License
         name: jsonPayload.type ?? '',
         url: '',
       };
-      const libraryJsonFilePath = path.join(aboutLibrariesConfigLibrariesDirPath, `${jsonPayload.name}.json`);
+      const libraryJsonFilePath = path.join(
+        aboutLibrariesConfigLibrariesDirPath,
+        `${normalizePackageName(jsonPayload.name)}.json`,
+      );
       const licenseJsonFilePath = path.join(aboutLibrariesConfigLicensesDirPath, `${licenseJsonPayload.hash}.json`);
 
       fs.writeFileSync(libraryJsonFilePath, JSON.stringify(libraryJsonPayload));
@@ -308,4 +311,8 @@ function findPackageRoot(entryPath: string) {
     if (fs.existsSync(path.join(currentDir, 'package.json'))) return currentDir;
     currentDir = path.dirname(currentDir);
   }
+}
+
+function normalizePackageName(packageName: string): string {
+  return packageName.replace('/', '_');
 }


### PR DESCRIPTION
- Added fallback for `package.json` resolution when `require.resolve` fails  
- Fixed escaping of package names in license plist (handles `@` and `/` correctly)  
- Implemented `toYaml()` to generate YAML from objects instead of manually concatenating strings… handling